### PR TITLE
Fix task ID generation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,8 @@ const App = () => {
   }, []);
 
   const handleAddTask = (task) => {
-    setTasks([...tasks, { ...task, id: tasks.length + 1 }]); // Mock ID for new tasks
+    const maxId = tasks.reduce((max, t) => (t.id > max ? t.id : max), 0);
+    setTasks([...tasks, { ...task, id: maxId + 1 }]); // Ensure unique ID
   };
 
   const handleEditTask = (updatedTask) => {


### PR DESCRIPTION
## Summary
- ensure new tasks always get a unique id by finding the current max id

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b5c615668832788369a19bfc7a2ca