### PR TITLE
Add local validation to TaskForm

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,6 +30,11 @@ button {
   border-radius: 20px;
 }
 
+.error-message {
+  color: red;
+  margin-bottom: 10px;
+}
+
 .task-item {
   display: flex;
   justify-content: space-between;

--- a/src/components/TaskForm.js
+++ b/src/components/TaskForm.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 const TaskForm = ({ onSave, taskToEdit }) => {
   const [title, setTitle] = useState('');
+  const [error, setError] = useState('');
 
   useEffect(() => {
     if (taskToEdit) {
@@ -12,11 +13,12 @@ const TaskForm = ({ onSave, taskToEdit }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (title.trim() === '') {
-      alert('Title is required');
+      setError('Title is required');
       return;
     }
     onSave({ ...taskToEdit, title });
     setTitle('');
+    setError('');
   };
 
   return (
@@ -24,9 +26,13 @@ const TaskForm = ({ onSave, taskToEdit }) => {
       <input
         type="text"
         value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        onChange={(e) => {
+          setTitle(e.target.value);
+          if (error) setError('');
+        }}
         placeholder="Enter task title"
       />
+      {error && <div className="error-message">{error}</div>}
       <button type="submit">{taskToEdit ? 'Update' : 'Add'} Task</button>
     </form>
   );

--- a/src/components/TaskForm.test.js
+++ b/src/components/TaskForm.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import TaskForm from './TaskForm';
+
+describe('TaskForm', () => {
+  test('shows error message when submitting empty title', () => {
+    const mockOnSave = jest.fn();
+    render(<TaskForm onSave={mockOnSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(mockOnSave).not.toHaveBeenCalled();
+    expect(screen.getByText('Title is required')).toBeInTheDocument();
+  });
+
+  test('calls onSave when title is provided', () => {
+    const mockOnSave = jest.fn();
+    render(<TaskForm onSave={mockOnSave} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/enter task title/i), { target: { value: 'New Task' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(mockOnSave).toHaveBeenCalledWith({ title: 'New Task' });
+    expect(screen.queryByText('Title is required')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- keep validation errors inside TaskForm state instead of using `alert`
- show error messages in the UI
- add styling for error messages
- test TaskForm validation logic

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b600d46108327b7324ff30e7bb43a