### PR TITLE
Handle API error and test

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,11 +7,15 @@ import { getTodosInfo } from './services/todosAPI';
 const App = () => {
   const [tasks, setTasks] = useState([]);
   const [taskToEdit, setTaskToEdit] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
     getTodosInfo()
       .then(response => setTasks(response.data.slice(0, 20))) // Limit to 20 tasks for tests
-      .catch(error => console.error('Error fetching tasks:', error));
+      .catch(error => {
+        console.error('Error fetching tasks:', error);
+        setErrorMessage('Failed to load tasks');
+      });
   }, []);
 
   const handleAddTask = (task) => {
@@ -35,6 +39,7 @@ const App = () => {
   return (
     <div className="App">
       <h1>Simple Task Manager</h1>
+      {errorMessage && <div className="error-message" role="alert">{errorMessage}</div>}
       <TaskForm onSave={handleSaveTask} taskToEdit={taskToEdit} />
       <TaskList tasks={tasks} onDelete={handleDeleteTask} onEdit={setTaskToEdit} />
     </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,26 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { getTodosInfo } from './services/todosAPI';
+
+jest.mock('./services/todosAPI');
+
+beforeEach(() => {
+  getTodosInfo.mockResolvedValue({ data: [] });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 test('renders Manager Text', () => {
   render(<App />);
   const linkElement = screen.getByText(/Manager/i);
   expect(linkElement).toBeInTheDocument();
+});
+
+test('shows error message when getTodosInfo rejects', async () => {
+  getTodosInfo.mockRejectedValue(new Error('Network Error'));
+  render(<App />);
+  const alert = await screen.findByRole('alert');
+  expect(alert).toHaveTextContent(/failed to load tasks/i);
 });


### PR DESCRIPTION
## Summary
- show API error message in the App component
- test API error handling in App

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684b61e88c248327a67ab623cee7b4cb